### PR TITLE
Add missing import

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import *
+from markupsafe import escape
 
 app = Flask(__name__)
 


### PR DESCRIPTION
The escape function is no longer part of Flask in the latest version. Flask's documentation says to import it directly from markupsafe.