### PR TITLE
Run Actions workflows on push to all branches except main

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,7 +2,8 @@ name: Black
 
 on:
   push:
-    branches: '!main'
+    branches-ignore:
+      - 'main'
   pull_request:
     branches: '**'
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,8 @@ name: Prettier
 
 on:
   push:
-    branches: '!main'
+    branches-ignore:
+      - 'main'
   pull_request:
     branches: '**'
   workflow_dispatch:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,8 @@ name: Pytest
 
 on:
   push:
-    branches: '!main'
+    branches-ignore:
+      - 'main'
   pull_request:
     branches: '**'
   workflow_dispatch:


### PR DESCRIPTION
This change adjusts the Actions workflows for this project to run on `push` to all branches except `main`. The previous rules were not working correctly for me. The `!main` exclusion rule requires prior inclusion rules such as:

```
on:
  workflow_run:
    workflows: ["Build"]
    types: [requested]
    branches:
      - 'releases/**'
      - '!releases/**-alpha'
```

When used alone, the exclusion rule causes the workflow to never be run on push. There's more info about this in the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-branches-and-tags). I believe this change correct the workflows to run on every push, except against main to avoid duplicate runs.