### PR TITLE
Import yaml directly

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -1,5 +1,6 @@
+import yaml
 import pytest
-from app import yaml, app
+from app import app
 from playwright.sync_api import Page, expect
 from random import choice
 from string import ascii_lowercase


### PR DESCRIPTION
The yaml module was previously imported here via its inclusion in `app`. This change will import it directly.