### PR TITLE
Rename maxPromptToken to maxPromptLength

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ def api():
     if not model_name in models:
         # 400 Bad Request
         return f"Error: Unknown model name '{model_name}'.", 400
-    if len(query) >= models[model_name]["maxPromptLength"]:
+    if len(query) >= models[model_name]["max_prompt_length"]:
         return "Error: The prompt was too long.", 413  # 413 Content Too Large
     if not "model" in models[model_name]:
         return (

--- a/config.yml
+++ b/config.yml
@@ -1,10 +1,10 @@
 models:
   - name: jncraton/LaMini-Flan-T5-783M-ct2-int8
     backend: ctranslate2
-    maxPromptLength: 250
+    max_prompt_length: 250
   - name: marella/gpt-2-ggml
     backend: ctransformers
-    maxPromptLength: 250
+    max_prompt_length: 250
 
 # When changing the logo, be sure to resize it to 30px by 30px for the best quality
 logo: /logos/default.png

--- a/test_main.py
+++ b/test_main.py
@@ -62,7 +62,7 @@ def test_query_too_big(page: Page):
         config_models = yaml.safe_load(f)["models"]
     page.goto("http://127.0.0.1:5000/playground")
     page.get_by_label("Prompt").click()
-    page.get_by_label("Prompt").fill("a " * config_models[0]["maxPromptLength"])
+    page.get_by_label("Prompt").fill("a " * config_models[0]["max_prompt_length"])
     page.get_by_role("button", name="Submit").click()
     chat_reply = page.locator("#outputResponse")
     expect(chat_reply).to_contain_text("Error: The prompt was too long.")
@@ -73,7 +73,7 @@ def test_query_too_big_api(client):
     with open("config.yml", "r") as f:
         config_models = yaml.safe_load(f)["models"]
     for model in config_models:
-        response = client.get(f"/api?input={'a ' * model['maxPromptLength']}")
+        response = client.get(f"/api?input={'a ' * model['max_prompt_length']}")
         assert response.status_code == 413
 
 


### PR DESCRIPTION
`maxPromptToken` is used to set the maximum number of characters allowed in a prompt, but using the word "token" incorrectly implies that it's a limit on the number of tokens. This change replaces "token" with "length".