### PR TITLE
fix logo hyperlink

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
       <ul>
         <li><a href="/status">Status</a></li>
         <li><a href="/playground" class="nav-active">Playground</a></li>
-        <img src="{{ logo }}" alt="logo" class="body_logo" />
+        <a href="/"><img src="{{ logo }}" alt="logo" class="body_logo" /></a>
       </ul>
     </nav>
 

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -14,19 +14,7 @@
       <ul>
         <li><a href="/status">Status</a></li>
         <li><a href="/playground">Playground</a></li>
-        <nav>
-          <a href="/">
-            {% if logo[0:6] == "/logos" %}
-            <img
-              src="{{ url_for('static', filename=logo) }}"
-              alt="logo"
-              class="body_logo"
-            />
-            {% else %}
-            <img src="{{ logo }}" alt="logo" class="body_logo" />
-            {% endif %}
-          </a>
-        </nav>
+        <a href="/"><img src="{{ logo }}" alt="logo" class="body_logo" /></a>
       </ul>
     </nav>
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -15,7 +15,7 @@
       <ul>
         <li><a href="/status" class="nav-active">Status</a></li>
         <li><a href="/playground">Playground</a></li>
-        <img src="{{ logo }}" alt="logo" class="body_logo" />
+        <a href="/"><img src="{{ logo }}" alt="logo" class="body_logo" /></a>
       </ul>
     </nav>
 


### PR DESCRIPTION
The hyperlink to the landing page on the logo was removed in #108 
This restores that, as it is a requested feature by the customer.
And it finished the last pull requests attempted change.